### PR TITLE
Use LDLIBS, not LDFLAGS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CFLAGS += -std=c99 -Wall -Wextra -pedantic `pkg-config --cflags libseccomp`
-LDFLAGS += `pkg-config --libs libseccomp`
+LDLIBS += `pkg-config --libs libseccomp`
 
 .PHONY: all
 all: antijack


### PR DESCRIPTION
Fixes build failure on systems that use `--as-needed` by default:

```console
$ make
cc -std=c99 -Wall -Wextra -pedantic `pkg-config --cflags libseccomp`  `pkg-config --libs libseccomp`  antijack.c   -o antijack
/usr/bin/ld: /tmp/ccIIdfwe.o: in function `dump_seccomp_pfc':
antijack.c:(.text+0x3a1): undefined reference to `seccomp_export_pfc'
/usr/bin/ld: /tmp/ccIIdfwe.o: in function `main':
antijack.c:(.text+0x506): undefined reference to `seccomp_init'
/usr/bin/ld: antijack.c:(.text+0x5a3): undefined reference to `seccomp_rule_add'
/usr/bin/ld: antijack.c:(.text+0x642): undefined reference to `seccomp_rule_add'
/usr/bin/ld: antijack.c:(.text+0x707): undefined reference to `seccomp_export_bpf'
/usr/bin/ld: antijack.c:(.text+0x7af): undefined reference to `seccomp_load'
/usr/bin/ld: antijack.c:(.text+0x807): undefined reference to `seccomp_release'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: antijack] Error 1
```