### PR TITLE
Document glibc version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ and is its counterpart in some sense, hence the name.
 
 - C99 compiler
 - Linux build and target host
+- glibc ≥ 2.32
 - [libseccomp](https://github.com/seccomp/libseccomp)
 
 


### PR DESCRIPTION
`strerrorname_np()` and `strerrordesc_np()` were added only in [glibc 2.32](https://lists.gnu.org/archive/html/info-gnu/2020-08/msg00002.html).