### PR TITLE
Fix seccomp filter for 64bit machines

### DIFF
--- a/antijack.c
+++ b/antijack.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
   now("Adding rule block TIOCSTI ioctls");
   const int res_tiocsti =
       seccomp_rule_add(ctx, SCMP_ACT_KILL_PROCESS, SCMP_SYS(ioctl), 1,
-                       SCMP_A1(SCMP_CMP_EQ, TIOCSTI));
+                       SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, TIOCSTI));
   if (res_tiocsti != 0) {
     exit_with(3, "Could not add rule to ioctl TIOCSTI.");
   }
@@ -140,7 +140,7 @@ int main(int argc, char *argv[]) {
   now("Adding rule block TIOCLINUX ioctls");
   const int res_tioclinux =
       seccomp_rule_add(ctx, SCMP_ACT_KILL_PROCESS, SCMP_SYS(ioctl), 1,
-                       SCMP_A1(SCMP_CMP_EQ, TIOCLINUX));
+                       SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFFFFFFFFu, TIOCLINUX));
   if (res_tioclinux != 0) {
     exit_with(4, "Could not add rule to block ioctl TIOCLINUX.");
   }


### PR DESCRIPTION
I came across this text in CVE-2019-10063:

> Flatpak versions since 0.8.1 address CVE-2017-5226 by using a seccomp filter to prevent sandboxed apps from using the TIOCSTI ioctl, which could otherwise be used to inject commands into the controlling terminal so that they would be executed outside the sandbox after the sandboxed app exits.
> This fix was incomplete: on 64-bit platforms, the seccomp filter could be bypassed by an ioctl request number that has TIOCSTI in its 32 least significant bits and an arbitrary nonzero value in its 32 most significant bits, which the Linux kernel would treat as equivalent to TIOCSTI.

The issue can be reproduced by sending ioctl request `TIOCSTI + 0x100000000` (eight zeros).