### PR TITLE
`linux.yml`: Bump to `ubuntu-24.04` and GCC 14

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,11 +22,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-13
-            cxx: g++-13
+          - cc: gcc-14
+            cxx: g++-14
             clang_major_version: null
             clang_repo_suffix: null
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
           - cc: clang-18
             cxx: clang++-18
             clang_major_version: 18


### PR DESCRIPTION
.. because `ubuntu-22.04` suddenly dropped GCC 13.

Related:
- https://github.com/actions/runner-images/issues/9866
- https://github.com/actions/runner-images/issues/9679